### PR TITLE
Defer access to application.poetry

### DIFF
--- a/poetry_grpc_plugin/plugins.py
+++ b/poetry_grpc_plugin/plugins.py
@@ -163,6 +163,9 @@ class GrpcApplicationPlugin(ApplicationPlugin):
             return
         config = self.load_config()
         if config is None:
+            logger.debug(
+                "Skipped update, [tool.poetry-grpc-plugin] or pyproject.toml missing."
+            )
             return
         if run_protoc(event.command.env.path, **config) != 0:
             raise Exception("Error: {} failed".format(event.command))

--- a/poetry_grpc_plugin/plugins.py
+++ b/poetry_grpc_plugin/plugins.py
@@ -159,7 +159,7 @@ class GrpcApplicationPlugin(ApplicationPlugin):
     def run_protoc(
         self, event: ConsoleCommandEvent, event_name: str, dispatcher: EventDispatcher
     ) -> None:
-        if not isinstance(event.command, UpdateCommand) or not self.protoc_command:
+        if not isinstance(event.command, UpdateCommand) or not self.application:
             return
         config = self.load_config()
         if config is None:


### PR DESCRIPTION
Accessing the `application.poetry` property forces load of `pyproject.toml`, which may not be present in the case of non project scoped poetry commands (e.g. `poetry new/init/self`) and subsequently fails the command.

This change defers loading of the project settings until the point the `protoc` command is constructed or when the hooked `update` command is invoked.
